### PR TITLE
Fix subjectspecialist cgb merge into sp4dev

### DIFF
--- a/assets/js/guides/LinkList.js
+++ b/assets/js/guides/LinkList.js
@@ -109,8 +109,8 @@ function LinkList(id,idSelector) {
     }
 
     // Load existing list behaviour
-    if ($('#LinkList-body').siblings().find('li')) {
-        loadDisplayList($('#LinkList-body').siblings().find('li'));
+    if ($('#LinkList-body').siblings().find('li').parents('ul.link-list-display').find('li')) {
+        loadDisplayList($('#LinkList-body').siblings().find('li').parents('ul.link-list-display').find('li'));
     }
 
     function loadDisplayList(list) {


### PR DESCRIPTION
[3bbc10f] 	fix LinkList so that li elements in the description are not included when importing a guide