### PR TITLE
merge fix-toc-order into sp4dev: Fix #619 TOC order by tab index

### DIFF
--- a/lib/SubjectsPlus/Control/Pluslet/TOC.php
+++ b/lib/SubjectsPlus/Control/Pluslet/TOC.php
@@ -49,7 +49,7 @@ class Pluslet_TOC extends Pluslet {
 			ON t.subject_id = s.subject_id
 			WHERE s.subject_id = '$this->_subject_id'
 			AND p.type != 'TOC'
-			ORDER BY ps.pcolumn, ps.prow ASC";
+			ORDER BY t.tab_index, ps.pcolumn, ps.prow ASC";
 
     //print $qs;
 


### PR DESCRIPTION
[23cb582] Fix #619 TOC order by tab index