### PR TITLE
adding a new allguides permission

### DIFF
--- a/control/admin/user.php
+++ b/control/admin/user.php
@@ -153,6 +153,7 @@ if (isset($_GET["browse"])) {
                 <p><strong>librarian</strong> means user shows up in lists of librarians.
                 <p><strong>supervisor</strong> means user shows up in list of supervisors
                 <p><strong>view_map</strong> lets user see the map of where everyone lives.  Probably only for muckymucks.  Might not be implemented on your site; check wiki for help.
+                <p><strong>allguides</strong> lets user edit any guides, even if they are not listed as an owner.
                 ");
 
     makePluslet(_("On Privilege"), $privs_blurb, "no_overflow");

--- a/control/guides/guide.php
+++ b/control/guides/guide.php
@@ -49,8 +49,14 @@ include ("../includes/header.php");
 $postvar_subject_id = scrubData ( $_GET ['subject_id'] );
 $this_id = $_GET ["subject_id"];
 
+// Editable if either a) they have admin, or b) they have allguides
+$canedit = 0;
+
+if (isset ( $_SESSION ["admin"] ) && $_SESSION ["admin"] == 1) { $canedit = 1; }
+if (isset ( $_SESSION ["allguides"] ) && $_SESSION ["allguides"] == 1) { $canedit = 1; }
+
 // See if they have permission to edit this guide
-if (! isset ( $_SESSION ["admin"] ) || $_SESSION ["admin"] != 1) {
+if ($canedit == 0) {
 	$q = "SELECT staff_id from staff_subject WHERE subject_id = '$this_id'
     AND staff_id = '" . $_SESSION ["staff_id"] . "'";
 	$db = new Querier ();

--- a/control/includes/config-default.php
+++ b/control/includes/config-default.php
@@ -27,7 +27,7 @@ $all_vtags = array( "collections", "instruction", "events", "exhibit", "services
 
 // These are the tags that denote permissions for a staff member.  They
 // will be used in a pipe-delimited list in the ptags field of the staff table.
-$all_ptags = array("talkback", "faq", "records", "eresource_mgr", "videos", "admin", "librarian", "supervisor", "view_map");
+$all_ptags = array("talkback", "faq", "records", "eresource_mgr", "videos", "admin", "librarian", "supervisor", "view_map", "allguides");
 
 // These are the tags associated with TalkBack entries.  Used in a pipe-delimited
 // list in the tbtags field of the talkback table. They can be


### PR DESCRIPTION
This allows you to set some users who can edit others' guides; previously, only admins could do this.