### PR TITLE
Sp4 dev merge into master  [223ce33] added myCopyClone.removeCloneDupMarkup()

### DIFF
--- a/assets/js/guides/copyClone.js
+++ b/assets/js/guides/copyClone.js
@@ -88,6 +88,7 @@ function copyClone() {
 		init : function() {
 		    myCopyClone.bindUiActions();
 		    myCopyClone.markAsLinked();
+			myCopyClone.removeCloneDupMarkup();
 		},
 		markAsLinked: function () {
 		    /**
@@ -99,6 +100,21 @@ function copyClone() {
 		        $(this).children('.titlebar').children('.titlebar_text').addClass('linked_pluslet');
 		    });
 
+		},
+
+		removeCloneDupMarkup: function () {
+
+			var clones = $('div[name="Clone"]');
+
+			$.each(clones, function (index, value) {
+
+				var clone = $(this).find('.pluslet_body');
+				var cloneContent = $(clone).find('.pluslet_body').html();
+
+				$(this).find('.pluslet_body').remove();
+
+				$( '<div class="pluslet_body">' + cloneContent + '</div>').insertAfter($(this).find('.titlebar'));
+			});
 		}
 	};
 

--- a/lib/SubjectsPlus/Control/Pluslet/Clone.php
+++ b/lib/SubjectsPlus/Control/Pluslet/Clone.php
@@ -89,6 +89,10 @@ require_once("Pluslet.php");
 
 		 switch($type) {
 
+             case "LinkList":
+                 $cloned_pluslet = new Pluslet_LinkList($master, null, $subject_id, 1);
+                 break;
+
 			 case "Related":
 				 $cloned_pluslet = new Pluslet_Related($master, null, $subject_id, 1);
 				 break;


### PR DESCRIPTION
[223ce33] added myCopyClone.removeCloneDupMarkup(); to copyClone.js so that duplicate markup is removed from cloned pluslets . the pluslet_body markup displayed twice causing the settings button to show for both new and clone pluslet