### PR TITLE
refactor preg_match so that it accounts for a space after the article…

### DIFF
--- a/lib/SubjectsPlus/Control/AzRecord/Title.php
+++ b/lib/SubjectsPlus/Control/AzRecord/Title.php
@@ -53,14 +53,14 @@ class Title implements TitleInterface,OutputInterface
      */
     public function setTitle($title)
     {
-        $re = "/\\b(the|a|an|la|les|el|las|los)/i";
+        $re = "/\\b(the|a|an|la|les|el|las|los)+[[:space:]]/i";
         preg_match($re, $title, $matches);
 
         if (isset($matches[0])) {
             $this->pre = $matches[0];
             $title_array = explode(" ",$title);
             if (isset($title_array[0])) {
-                if ($title_array[0] == $matches[0]) {
+                if ($title_array[0] == trim($matches[0])) {
                     $title_array[0] = "";
                 }
                 $title = trim(implode(" ",$title_array));


### PR DESCRIPTION
… such as A or An