### PR TITLE
Adding a skip to main content link; helps with Issue #214

### DIFF
--- a/assets/css/public/cleanwhite.css
+++ b/assets/css/public/cleanwhite.css
@@ -1797,6 +1797,30 @@ ul.guide-listing li .fa {color: #666; font-size:0.9em; cursor: pointer; margin-r
     margin-bottom:5%;
 }
 
+/* For skip to main content links */
+a#skiptocontent {
+        padding:6px;
+        position: absolute;
+        top:-40px;
+        left:0px;
+        color:white;
+        border-right:1px solid white;
+        border-bottom:1px solid white;
+        border-bottom-right-radius:8px;
+        background:#BF1722;
+        -webkit-transition: top 1s ease-out;
+    transition: top 1s ease-out;
+    z-index: 100;
+}
+
+a#skiptocontent:focus {
+        position:absolute;
+        left:0px;
+        top:0px;
+        outline-color:transparent;
+        -webkit-transition: top .1s ease-in;
+    transition: top .1s ease-in;
+}
 
 
 

--- a/lib/SubjectsPlus/Control/DbHandler.php
+++ b/lib/SubjectsPlus/Control/DbHandler.php
@@ -365,7 +365,7 @@ ORDER BY newtitle
 		}
 
 		// prepare header
-		$items = "<table width=\"98%\" class=\"item_listing trackContainer\">";
+		$items = "<div id=\"content-after-navs\" tabindex=\"-1\"><table width=\"98%\" class=\"item_listing trackContainer\">";
 
 		$row_count = 0;
 		$colour1 = "oddrow";
@@ -444,7 +444,7 @@ ORDER BY newtitle
 			$row_count ++;
 		}
 
-		$items .= "</table>";
+		$items .= "</table></div>";
 		return $items;
 	}
 	function generateLayout($row_colour, $url, $target, $item_title, $information, $information1, $icons, $helpguide, $display_note_text, $bonus, $favorite_link_rand_id) {

--- a/subjects/collection.php
+++ b/subjects/collection.php
@@ -149,6 +149,7 @@ $layout = makePluslet("", $guide_results, "","",FALSE);
 
 ?>
 <br />
+<div id="content-after-navs" tabindex="-1">
 <div class="pure-g" id="guidesplash">
 <div class="pure-u-1 pure-u-md-2-3" id="listguides">
 <?php print $layout; ?>
@@ -187,6 +188,7 @@ $layout = makePluslet("", $guide_results, "","",FALSE);
         <br />
 
     </div>
+</div>
 </div>
 <?php
 ///////////////////////////

--- a/subjects/faq.php
+++ b/subjects/faq.php
@@ -308,7 +308,7 @@ foreach ($collections_result as $myrow1) {
 
 ?>
 <br />
-<div class="pure-g">
+<div class="pure-g" id="content-after-navs" tabindex="-1">
 <div class="pure-u-1 pure-u-md-2-3">
 <?php
 //$num_faqs = $row_count - 1;

--- a/subjects/guide.php
+++ b/subjects/guide.php
@@ -274,14 +274,17 @@ if (isset ($header_type) && $header_type == 'um-new') {
         </div>
 		<!-- end tab-container -->
 
+	<div id="content-after-navs">
 		<div id="tab-body" class="<?php print $bonus_class; ?>">
             <?php
             $lobjGuide->outputTabs('public');
 
             ?>
-        </div>
+        	</div>
 		<!-- end tab-body -->
 
+	</div>
+	<!-- end content-after-navs -->
 	</div> <!-- end main-content -->
 </div> <!-- end tabs -->
 

--- a/subjects/includes/header.php
+++ b/subjects/includes/header.php
@@ -58,6 +58,7 @@ $v2styles = TRUE;
 
 <div id="header"> 
     <div id="header_inner_wrap">
+        <a href="#content-after-navs" id="skiptocontent">Skip to Main Content</a>
         <div class="pure-g">
             <div class="pure-u-1 pure-u-md-1-5">
                 <a href="<?php print $PublicPath; ?>"><img class="main_logo" src="<?php print $AssetPath; ?>images/public/logo.png" alt="Home Page" /></a>
@@ -77,4 +78,4 @@ $v2styles = TRUE;
             <div id="content_roof"></div> <!-- end #content_roof -->
             <div id="shadowkiller"></div> <!--end #shadowkiller-->
         
-            <div id="body_inner_wrap">
+            <div id="body_inner_wrap" tabindex="-1">

--- a/subjects/index.php
+++ b/subjects/index.php
@@ -316,7 +316,7 @@ include("includes/header.php");
   
   </div><!--end 2/3 main area-->
 
-  <div class="pure-u-1 pure-u-lg-1-3">
+  <div class="pure-u-1 pure-u-lg-1-3" id="content-after-navs">
 
       
           <div class="find-expert-area-circ">

--- a/subjects/search.php
+++ b/subjects/search.php
@@ -118,7 +118,10 @@ $subtitle = _("Search Results for ") . $_POST['searchterm'];
     </div>
     </div>
 
+    <div id="content-after-navs" tabindex="-1">
 	<?php makePluslet($subtitle, $search_result, "no_overflow"); ?> 
+    </div>
+
 
     </div>
     <div class="pure-u-1-2">

--- a/subjects/staff.php
+++ b/subjects/staff.php
@@ -43,7 +43,8 @@ $alphabet = getLetters($our_cats, $selected_letter);
 
 if ($selected_letter == "A-Z") {
 
-$intro = "<p><i class=\"fa fa-info-circle\" aria-hidden=\"true\"></i> " . _("Click on a name for more information.") ."</p><br />";
+$intro = "<p><i class=\"fa fa-info-circle\" aria-hidden=\"true\"></i> " . _("Click on a name for more information.") .
+"<br /><div id=\"content-after-navs\" tabindex=\"-1\">";
 
 }
 
@@ -52,7 +53,7 @@ $out = $staff_data->writeTable($selected_letter);
 
 
 // Assemble the content for our main pluslet
-$display = $alphabet . $intro . $out;
+$display = $alphabet . $intro . $out . "</div>";
 
 ////////////////////////////
 // Now we are finally read to display the page

--- a/subjects/staff_details.php
+++ b/subjects/staff_details.php
@@ -154,7 +154,7 @@ $page_title = _("Staff Listing: ") . $fullname;
 include("includes/header.php");
 
 ?>
-<div class="pure-g">
+<div class="pure-g" id="content-after-navs" tabindex="-1">
 <div class="pure-u-2-3">
     <div class="pluslet">
         <div class="titlebar">

--- a/subjects/talkback.php
+++ b/subjects/talkback.php
@@ -478,7 +478,7 @@ include("includes/header.php");
 
 ?>
     <br />
-    <div class="pure-g">
+    <div class="pure-g" id="content-after-navs" tabindex="-1">
         <div class="pure-u-1 pure-u-lg-2-3">
             <?php print $feedback . $stk_message; ?>
             <div class="pluslet_simple no_overflow">

--- a/subjects/video.php
+++ b/subjects/video.php
@@ -163,7 +163,7 @@ if ($num_rows) {
 include("includes/header.php");
 ?>
 <br />
-<div class="pure-g">
+<div class="pure-g" id="content-after-navs" tabindex="-1">
 <div class="pure-u-1 pure-u-md-2-3">
     <div class="pluslet">
         <div class="titlebar">


### PR DESCRIPTION
This adds a Skip to Main Content (aka skip nav) link to the default theme, based on guidance from WebAIM: https://webaim.org/techniques/skipnav/.  This only adds it to the public-facing site, not the librarian-facing site.  Also, if you're using a different header.php, you'll have to add the link yourself.

To test:
* Load this commit
* Open any public-facing page.
* Press Tab -- you should see a Skip to Main Content link in the top left corner
* Press Enter -- your screen should move down past the initial navigation.
* Press Tab -- it should focus the first selectable element within the main content, rather than focusing something in the navigation.

This is one of the issues mentioned in Issue #214.