### PR TITLE
Adding empty alt to decorative icons in recent activity box

### DIFF
--- a/control/includes/functions.php
+++ b/control/includes/functions.php
@@ -812,7 +812,7 @@ function seeRecentChanges( $staff_id, $limit = 10 ) {
 					break;
 			}
 
-			$recent_activity .= "<div class=\"recent-activity $row_colour\"> <img src=\"$IconPath/required.png\"  /></img> $intro";
+			$recent_activity .= "<div class=\"recent-activity $row_colour\"> <img src=\"$IconPath/required.png\" alt=\"\" /></img> $intro";
 			if ( $myrow2["2"] != "" ) {
 				$recent_activity .= ": <a href=\"$linkit\" classs=\"recent-activity-link\" title=\"Took place: $myrow2[4]\">$myrow2[2]</a>";
 			}


### PR DESCRIPTION
The "Recent Activity" box on the main control page has a bunch of icons.  The icons didn't have any alt text.  Since these icons are decorative, this commit adds alt=""