### PR TITLE
Spaced guide name fix

### DIFF
--- a/control/edit-config.php
+++ b/control/edit-config.php
@@ -168,7 +168,7 @@ if ( ! is_writable( $lstrConfigFilePath ) ) {
 
 		"guide_types" => array(
 			_( "Guide Types" ),
-			_( "These are the different ways you may organize your guides." ),
+			_( "These are the different ways you may organize your guides.<br>(20 character limit per Guide Type.)" ),
 			"array",
 			"guide",
 			"large",

--- a/subjects/index.php
+++ b/subjects/index.php
@@ -289,10 +289,6 @@ include("includes/header.php");
     foreach ($guide_types as $key) {
         $trimmed_guide_type = str_replace(' ', '-', $key);
 
-        // print_r( array(
-        //     '$trimmed_guide_type' => $trimmed_guide_type
-        // ));
-
         $guide_type_btns .= "<li><a id=\"show-" . $trimmed_guide_type . "\" name=\"show$trimmed_guide_type\" href=\"#section-" . $trimmed_guide_type . "\">";
         
         $guide_type_btns .= ucfirst($key) . " Guides</a></li>\n";

--- a/subjects/index.php
+++ b/subjects/index.php
@@ -293,8 +293,6 @@ include("includes/header.php");
         
         $guide_type_btns .= ucfirst($key) . " Guides</a></li>\n";
     }
-    
-    // die;
 
     $guide_type_btns .= "<li><a id=\"show-Collection\" name=\"showCollection\" href=\"#section-Collection\">Collections</a></li></ul>";
 

--- a/subjects/index.php
+++ b/subjects/index.php
@@ -224,7 +224,9 @@ include("includes/header.php");
               $col_1 .= "</ul></div>";
               $col_2 .= "</ul></div>";
 
-              $layout .= "<div class=\"guide_list_container\"><div class=\"pure-g guide_list\"><div class=\"pure-u-1 guide_list_header\"><a name=\"section-$value\"></a><h3>$value</h3></div>" . $col_1 . $col_2 ."</div></div>";
+              $trimmed_guide_type = str_replace(' ', '-', $value);
+
+              $layout .= "<div class=\"guide_list_container\"><div class=\"pure-g guide_list\"><div class=\"pure-u-1 guide_list_header\"><a name=\"section-$trimmed_guide_type\"></a><h3>$value</h3></div>" . $col_1 . $col_2 ."</div></div>";
               
           } //end if
 
@@ -285,10 +287,18 @@ include("includes/header.php");
     if (in_array('Placeholder', $guide_types)) { unset($guide_types[array_search('Placeholder',$guide_types)]); }
 
     foreach ($guide_types as $key) {
-        $guide_type_btns .= "<li><a id=\"show-" . ucfirst($key) . "\" name=\"show$key\" href=\"#section-" . ucfirst($key) . "\">";
+        $trimmed_guide_type = str_replace(' ', '-', $key);
+
+        // print_r( array(
+        //     '$trimmed_guide_type' => $trimmed_guide_type
+        // ));
+
+        $guide_type_btns .= "<li><a id=\"show-" . $trimmed_guide_type . "\" name=\"show$trimmed_guide_type\" href=\"#section-" . $trimmed_guide_type . "\">";
         
         $guide_type_btns .= ucfirst($key) . " Guides</a></li>\n";
     }
+    
+    // die;
 
     $guide_type_btns .= "<li><a id=\"show-Collection\" name=\"showCollection\" href=\"#section-Collection\">Collections</a></li></ul>";
 


### PR DESCRIPTION
Fix allows proper linking on main public facing splash page ( /subjects/index.php ) for Guide Types that include a space.

Also adds a note on the admin config page (on the "Guides/Records" tab) clarifying that Guide Types have a 20-character limit by default.

Closes Issue #1324 