### PR TITLE
Remove group_by clause from seeRecentChanges function

### DIFF
--- a/control/includes/functions.php
+++ b/control/includes/functions.php
@@ -721,14 +721,12 @@ function seeRecentChanges( $staff_id, $limit = 10 ) {
 		$sq2 = "SELECT ourtable, record_id, record_title, message, date_added
         FROM chchchanges
         WHERE staff_id = '" . $staff_id . "'
-        GROUP BY record_title, message, ourtable
         ORDER BY date_added DESC
         LIMIT 0, $limit";
 	} else {
 		$sq2 = "SELECT ourtable, record_id, record_title, message, date_added, CONCAT( fname, ' ', lname ) AS fullname
         FROM chchchanges, staff
         WHERE chchchanges.staff_id = staff.staff_id
-        GROUP BY record_title, message, ourtable
         ORDER BY date_added DESC
         LIMIT 0 , $limit";
 	}


### PR DESCRIPTION
[#1455]
remove group_by clause from seeRecentChanges function to address the mysql group by change in v5.7