### PR TITLE
remove calls to get_magic_quotes_gpc()

### DIFF
--- a/ckeditor/plugins/subsplus_resource/php/getResourceRadioListSearch.php
+++ b/ckeditor/plugins/subsplus_resource/php/getResourceRadioListSearch.php
@@ -34,11 +34,7 @@ if (isset($_POST["search_terms"])) {
 
     $content = '<strong>Results</strong><br />';
 
-    if (get_magic_quotes_gpc()) {
-        $searcher = scrubData($_POST["search_terms"]);
-    } else {
-        $searcher = addslashes(scrubData($_POST["search_terms"]));
-    }
+    $searcher = addslashes(scrubData($_POST["search_terms"]));
 
     $searcher = "%" . $searcher . "%";
     $statement = $connection->prepare("SELECT title_id, title FROM title WHERE title LIKE :searcher ORDER BY title");

--- a/control/guides/helpers/guide_data.php
+++ b/control/guides/helpers/guide_data.php
@@ -201,15 +201,9 @@ function modifyDB($id, $type) {
         $pluslet_clone = 0;
     }
     // let's not have those errant slashes
-    if (get_magic_quotes_gpc ()) {
-        $pluslet_title = stripcslashes(stripcslashes($pluslet_title));
-        $pluslet_body = stripslashes(stripslashes($pluslet_body));
-        $pluslet_extra = stripslashes(stripslashes($pluslet_extra));
-    } else {
-        $pluslet_title = stripcslashes($pluslet_title);
-        $pluslet_body = stripslashes($pluslet_body);
-        $pluslet_extra = stripslashes($pluslet_extra);
-    }
+    $pluslet_title = stripcslashes($pluslet_title);
+    $pluslet_body = stripslashes($pluslet_body);
+    $pluslet_extra = stripslashes($pluslet_extra);
     switch ($type) {
         case "insert":
             $q = sprintf("INSERT INTO pluslet (title, body, type, clone, extra, hide_titlebar, collapse_body, titlebar_styling, favorite_box, target_blank_links) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)", $db->quote($pluslet_title), $db->quote($pluslet_body), $db->quote($pluslet_type), $db->quote($pluslet_clone), $db->quote($pluslet_extra), $db->quote($pluslet_hide_titlebar), $db->quote($pluslet_collapse_body), $db->quote($pluslet_titlebar_styling), $db->quote($pluslet_favorite_box), $db->quote($pluslet_target_blank_links));

--- a/control/includes/functions.php
+++ b/control/includes/functions.php
@@ -495,10 +495,6 @@ function scrubData( $string, $type = "text" ) {
 
 	switch ( $type ) {
 		case "text":
-// magic quotes test
-			if ( get_magic_quotes_gpc() ) {
-				$string = stripslashes( $string );
-			}
 			$string = strip_tags( $string );
 			$string = htmlspecialchars( $string, ENT_QUOTES );
 			$config   = HTMLPurifier_Config::createDefault();
@@ -507,10 +503,6 @@ function scrubData( $string, $type = "text" ) {
 			$string   = $purifier->purify( $string );
 			break;
 		case "richtext":
-// magic quotes test
-			if ( get_magic_quotes_gpc() ) {
-				$string = stripslashes( $string );
-			}
 			break;
 		case "richtext_html_purifier":
 			$config   = HTMLPurifier_Config::createDefault();
@@ -519,10 +511,6 @@ function scrubData( $string, $type = "text" ) {
 			$string   = $purifier->purify( $string );
 			break;
 		case "email":
-// magic quotes test
-			if ( get_magic_quotes_gpc() ) {
-				$string = stripslashes( $string );
-			}
 			//removes any tags protecting against javascript injection
 			$string = filter_var( $string, FILTER_SANITIZE_EMAIL );
 

--- a/lib/ims-blti/OAuth.php
+++ b/lib/ims-blti/OAuth.php
@@ -225,15 +225,6 @@ class OAuthRequest {
       $parameters = OAuthUtil::parse_parameters($_SERVER['QUERY_STRING']);
 
       $ourpost = $_POST;
-      // Deal with magic_quotes
-      // http://www.php.net/manual/en/security.magicquotes.disabling.php
-      if ( get_magic_quotes_gpc() ) {
-         $outpost = array();
-         foreach ($_POST as $k => $v) {
-            $v = stripslashes($v);
-            $ourpost[$k] = $v;
-         }
-      }
      // Add POST Parameters if they exist
       $parameters = array_merge($parameters, $ourpost);
 


### PR DESCRIPTION
Since get_magic_quotes_gpc() will always return false, the proposed
changes are direct.

The two calls that are remaining shouldn't be reached; one is
sample code from CKEditor and the other is part of capability
checking by HTMLPurifier.

Closes #1468