### PR TITLE
Remove chmod calls from Config.php

### DIFF
--- a/control/edit-config.php
+++ b/control/edit-config.php
@@ -1192,7 +1192,7 @@ if ( ! is_writable( $lstrConfigFilePath ) ) {
 				//if the mod_rewrite option changed
 				if ( $lobjConfig->isNewModRewrite() ) {
 					//write the approriate .htaccess file to given path
-					$lobjConfig->wrtieModRewriteFile( dirname( dirname( __FILE__ ) ) . DIRECTORY_SEPARATOR . 'subjects' . DIRECTORY_SEPARATOR . '.htaccess' );
+					$lobjConfig->writeModRewriteFile( dirname( dirname( __FILE__ ) ) . DIRECTORY_SEPARATOR . 'subjects' . DIRECTORY_SEPARATOR . '.htaccess' );
 				}
 
 			} else {

--- a/lib/SubjectsPlus/Control/Config.php
+++ b/lib/SubjectsPlus/Control/Config.php
@@ -287,17 +287,15 @@ class Config {
 				}
 			}
 
-			//close and change permissions of file
-			fclose( $lhndFile );
-
-			return chmod( $this->lstrConfigPath, 0666 );
+			//close file
+			return fclose( $lhndFile );
 		}
 
 		return false;
 	}
 
 	/**
-	 * sp_Config::wrtieModRewriteFile() - this method, depending on the new values
+	 * sp_Config::writeModRewriteFile() - this method, depending on the new values
 	 * 'mod_rewrite', write the .htaccess file to make prettier URL in the subject
 	 * folder
 	 *
@@ -305,7 +303,7 @@ class Config {
 	 *
 	 * @return boolean
 	 */
-	public function wrtieModRewriteFile( $lstrModRewritePath = '' ) {
+	public function writeModRewriteFile( $lstrModRewritePath = '' ) {
 		if ( $lstrModRewritePath == '' ) {
 			return false;
 		}
@@ -349,10 +347,8 @@ class Config {
 			}
 		}
 
-		//close file and change permissions
-		fclose( $lhndFile );
-
-		return chmod( $lstrModRewritePath, 0666 );
+		//close file
+		return fclose( $lhndFile );
 	}
 
 	/**


### PR DESCRIPTION
Stop calling chmod when writing config.php and .htaccess. If fopen worked then there's no need, and if it didn't we've already bailed out anyway. Also corrected spelling of wrtieModRewriteFile since it was being edited.

Closes #1484

Signed-off-by: Jason Boyer <jboyer@equinoxinitiative.org>