### PR TITLE
Databases/Records Enhancements

### DIFF
--- a/assets/css/admin/admin_styles.css
+++ b/assets/css/admin/admin_styles.css
@@ -3273,7 +3273,7 @@ div.ctag_list a:hover {
 
 }
 
-.ctag-on, .aztag-on, .lookup_button {
+.ctag-on, .aztag-on, .lookup_button, .toggle-on {
   background-color: #C03957;
   color: #fff;
   margin: 0 2px;
@@ -3289,7 +3289,7 @@ div.ctag_list a:hover {
 .lookup_button {
   background-color: #F37521;
 }
-.ctag-off, .aztag-off {
+.ctag-off, .aztag-off, .toggle-off {
   background-color: #ccc;
   color: #333;
   margin: 0 2px;

--- a/control/includes/functions.php
+++ b/control/includes/functions.php
@@ -292,19 +292,40 @@ function uploader2( $temp_path, $target_path ) {
 	}
 }
 
-function getSubBoxes( $prefix = "", $trunc = "", $all_subs = 0 ) {
+function getSubBoxes( $prefix = "", $trunc = "", $subs = "") {
 
 	$subs_option_boxes = "";
 
-	if ( $all_subs == "1" ) {
-		$subs_query = "SELECT distinct subject_id, subject, type FROM subject ORDER BY type, subject";
-	} else {
-		$subs_query = "SELECT distinct s.subject_id, subject, type
-            FROM subject s, staff_subject ss
-            WHERE s.subject_id = ss.subject_id
-            AND ss.staff_id = " . $_SESSION['staff_id'] . "
-            ORDER BY type, subject";
+	switch($subs) {
+		case "1": // all types
+		case "all":
+			// all types
+			$subs_query = "SELECT distinct subject_id, subject, type FROM subject ORDER BY type, subject";
+			break;
+		case "subject":
+			// only by "Subject" type
+			$subs_query = "SELECT distinct subject_id, subject, type FROM subject WHERE type LIKE 'Subject' AND active = '1' ORDER BY type, subject";
+			break;
+		case "staff":
+		default:
+			$subs_query = "SELECT distinct s.subject_id, subject, type
+				FROM subject s, staff_subject ss
+				WHERE s.subject_id = ss.subject_id
+				AND ss.staff_id = " . $_SESSION['staff_id'] . "
+				ORDER BY type, subject";
+			break;
+			
 	}
+
+	// if ( $subs == "all" ) {
+	// 	$subs_query = "SELECT distinct subject_id, subject, type FROM subject ORDER BY type, subject";
+	// } else {
+	// 	$subs_query = "SELECT distinct s.subject_id, subject, type
+    //         FROM subject s, staff_subject ss
+    //         WHERE s.subject_id = ss.subject_id
+    //         AND ss.staff_id = " . $_SESSION['staff_id'] . "
+    //         ORDER BY type, subject";
+	// }
 
 	$db          = new Querier;
 	$subs_result = $db->query( $subs_query );

--- a/control/records/record.php
+++ b/control/records/record.php
@@ -244,6 +244,12 @@ print "</div>"; // close #maincontent
 
             if (!our_sub_id) { return false;} // Only add subjects with values
 
+            // check whether id is already in subject list
+            if ($('#subject_list div').hasClass('new_subject-' + our_sub_id)) {
+                alert("Thwarted! Subject has already been added.");
+                return false; 
+            }
+
             var our_sub_text = $('select[name*=subject_id] :selected').text();
             var our_source_text = $('select[name=default_source_id] :selected').text();
             var our_source_id = $('select[name=default_source_id] :selected').val();

--- a/lib/SubjectsPlus/Control/DbHandler.php
+++ b/lib/SubjectsPlus/Control/DbHandler.php
@@ -156,7 +156,25 @@ class DbHandler {
         WHERE subject_id = :subject_id
         	AND eres_display = 'Y'
         	AND dbbysub_active = 1
-        ORDER BY newtitle" );
+		UNION
+			SELECT DISTINCT LEFT(alternate_title,1) as initial, alternate_title as newtitle, t.description, location, access_restrictions, t.title_id as this_record,eres_display, display_note, pre, citation_guide, ctags, helpguide,alternate_title
+			FROM title as t
+					INNER JOIN location_title as lt
+								ON t.title_id = lt.title_id
+					INNER JOIN location as l
+								ON lt.location_id = l.location_id
+					INNER JOIN restrictions as r
+								ON l.access_restrictions = r.restrictions_id
+					INNER JOIN rank as rk
+								ON rk.title_id = t.title_id
+					INNER JOIN source as s
+								ON rk.source_id = s.source_id
+		WHERE subject_id = :subject_id
+			AND eres_display = 'Y'
+			AND dbbysub_active = 1
+			AND t.alternate_title IS NOT NULL
+			AND t.alternate_title != ''
+		ORDER BY newtitle" );
 
 						$statement->bindParam ( ":subject_id", $subject_id );
 						$statement->execute ();

--- a/lib/SubjectsPlus/Control/Record.php
+++ b/lib/SubjectsPlus/Control/Record.php
@@ -325,8 +325,8 @@ class Record {
 		  <div class=\"pluslet_body\">
 		  
 		  <!-- ctags for subjects by type -->
-		  <div id=\"ctags_selection\" align=\"left\" style=\"margin-top: 2%;\">
-		  	<span id=\"subject_tag\" class=\"toggle-on\">By Subject</span>
+		  <div id=\"ctags_selection\" align=\"left\" style=\"margin-top: 2%; margin-bottom: 2%;\">
+		  	<span id=\"subject_tag\" class=\"toggle-on\">DB by Subject</span>
 		  	<span id=\"all_tag\" class=\"toggle-off\">All</span>
 		  </div>
 

--- a/lib/SubjectsPlus/Control/Record.php
+++ b/lib/SubjectsPlus/Control/Record.php
@@ -313,25 +313,77 @@ class Record {
 	}
 
 	if (isset($_SESSION["eresource_mgr"]) && $_SESSION["eresource_mgr"] == "1") {
-		$subject_string = getSubBoxes('', 50, 1);
+		$all_string = getSubBoxes('', 50, "all");
+		$subject_string = getSubBoxes('', 50, "subject");
+
+		echo "
+		<div class=\"pluslet no_overflow\">
+		  <div class=\"titlebar\">
+			<div class=\"titlebar_text\">" . _("Subjects") . "</div>
+			<div class=\"titlebar_options\"></div>
+		  </div>
+		  <div class=\"pluslet_body\">
+		  
+		  <!-- ctags for subjects by type -->
+		  <div id=\"ctags_selection\" align=\"left\" style=\"margin-top: 2%;\">
+		  	<span id=\"subject_tag\" class=\"ctag-on\">By Subject</span>
+		  	<span id=\"all_tag\" class=\"ctag-off\">All</span>
+		  </div>
+
+		  <select id=\"select_subject\"name=\"subject_id[]\"><option value=\"\">" . _("-- Select Subject--") . "</option>
+		  $subject_string
+		  </select>
+		  <div id=\"subject_list\">$subject_list</div> <!-- subjects inserted here -->
+		  </div>
+		  </div>
+		  <script type=\"text/javascript\">
+			$(document).ready(function() {
+				$('#all_tag').click(function() {
+					$('#select_subject').empty().append('<option value=\"\">" . _("-- Select --") . "</option>" .  str_replace("'", "\\'", $all_string) . "');
+					$('#subject_tag').removeClass().addClass('ctag-off');
+				});
+
+				$('#subject_tag').click(function() {
+					$('#select_subject').empty().append('<option value=\"\">" . _("-- Select Subject--") . "</option>" .  str_replace("'", "\\'", $subject_string) . "');
+					$('#all_tag').removeClass().addClass('ctag-off');
+				});
+
+			});
+		  </script>
+		 
+		  ";
 	} else {
 		$subject_string = getSubBoxes('', 50);
+		echo "
+		<div class=\"pluslet no_overflow\">
+		  <div class=\"titlebar\">
+			<div class=\"titlebar_text\">" . _("Subjects") . "</div>
+			<div class=\"titlebar_options\"></div>
+		  </div>
+		  <div class=\"pluslet_body\">
+		  
+		  <select id=\"select_subject\"name=\"subject_id[]\"><option value=\"\">" . _("-- Select --") . "</option>
+		  $subject_string
+		  </select>
+		  <div id=\"subject_list\">$subject_list</div> <!-- subjects inserted here -->
+		  </div>
+		  </div>";
 	}
 
-	echo "
-  <div class=\"pluslet no_overflow\">
-    <div class=\"titlebar\">
-      <div class=\"titlebar_text\">" . _("Subjects") . "</div>
-      <div class=\"titlebar_options\"></div>
-    </div>
-    <div class=\"pluslet_body\">
+// 	echo "
+//   <div class=\"pluslet no_overflow\">
+//     <div class=\"titlebar\">
+//       <div class=\"titlebar_text\">" . _("Subjects") . "</div>
+//       <div class=\"titlebar_options\"></div>
+//     </div>
+//     <div class=\"pluslet_body\">
 	
-	<select id=\"select_subject\"name=\"subject_id[]\"><option value=\"\">" . _("-- Select --") . "</option>
-	$subject_string
-	</select>
-	<div id=\"subject_list\">$subject_list</div> <!-- subjects inserted here -->
-	</div>
-	</div>";
+// 	<select id=\"select_subject\"name=\"subject_id[]\"><option value=\"\">" . _("-- Select --") . "</option>
+// 	$subject_string
+// 	</select>
+// 	<div id=\"subject_list\">$subject_list</div> <!-- subjects inserted here -->
+// 	</div>
+// 	</div>";
 
   	$this->outputRelatedPluslets();
   	print "</div></form>";

--- a/lib/SubjectsPlus/Control/Record.php
+++ b/lib/SubjectsPlus/Control/Record.php
@@ -326,8 +326,8 @@ class Record {
 		  
 		  <!-- ctags for subjects by type -->
 		  <div id=\"ctags_selection\" align=\"left\" style=\"margin-top: 2%;\">
-		  	<span id=\"subject_tag\" class=\"ctag-on\">By Subject</span>
-		  	<span id=\"all_tag\" class=\"ctag-off\">All</span>
+		  	<span id=\"subject_tag\" class=\"toggle-on\">By Subject</span>
+		  	<span id=\"all_tag\" class=\"toggle-off\">All</span>
 		  </div>
 
 		  <select id=\"select_subject\"name=\"subject_id[]\"><option value=\"\">" . _("-- Select Subject--") . "</option>
@@ -340,12 +340,14 @@ class Record {
 			$(document).ready(function() {
 				$('#all_tag').click(function() {
 					$('#select_subject').empty().append('<option value=\"\">" . _("-- Select --") . "</option>" .  str_replace("'", "\\'", $all_string) . "');
-					$('#subject_tag').removeClass().addClass('ctag-off');
+					$('#all_tag').attr('class', 'toggle-on');
+					$('#subject_tag').attr('class', 'toggle-off');
 				});
 
 				$('#subject_tag').click(function() {
-					$('#select_subject').empty().append('<option value=\"\">" . _("-- Select Subject--") . "</option>" .  str_replace("'", "\\'", $subject_string) . "');
-					$('#all_tag').removeClass().addClass('ctag-off');
+					$('#select_subject').empty().append('<option value=\"\">" . _("-- Select Subject--") . "</option>" .  str_replace("'", "\\'", $subject_string) . "');	
+					$('#all_tag').attr('class', 'toggle-off');
+					$('#subject_tag').attr('class', 'toggle-on');
 				});
 
 			});

--- a/lib/SubjectsPlus/Control/Record.php
+++ b/lib/SubjectsPlus/Control/Record.php
@@ -340,12 +340,14 @@ class Record {
 			$(document).ready(function() {
 				$('#all_tag').click(function() {
 					$('#select_subject').empty().append('<option value=\"\">" . _("-- Select --") . "</option>" .  str_replace("'", "\\'", $all_string) . "');
+					$('#select_subject').val('').change();
 					$('#all_tag').attr('class', 'toggle-on');
 					$('#subject_tag').attr('class', 'toggle-off');
 				});
 
 				$('#subject_tag').click(function() {
 					$('#select_subject').empty().append('<option value=\"\">" . _("-- Select Subject--") . "</option>" .  str_replace("'", "\\'", $subject_string) . "');	
+					$('#select_subject').val('').change();
 					$('#all_tag').attr('class', 'toggle-off');
 					$('#subject_tag').attr('class', 'toggle-on');
 				});


### PR DESCRIPTION
**Addresses Issue [#1522]** On "control/records/record.php" within the Subjects section, there are now two options, filter "By Subject" or "All". The "By Subject" option will limit the dropdown to only public facing subjects, while the "All" option will display everything in the dropdown regardless of type or display status.

**Addresses Issue [#1523]** On "subjects/databases.php", when searching databases by subject, entries with an alternate title will have an additional entry in the results showing the alternate title and directing to the same location.