### PR TITLE
Fix the list of Newest Databases URLs

### DIFF
--- a/subjects/index.php
+++ b/subjects/index.php
@@ -137,7 +137,7 @@ $newlist = "<ul>\n";
         $db_url = $proxyURL;
     }
 
-    $newlist .= "<li><a href=\"$db_url$myrow[1][0]\">$myrow[0]</a></li>\n";
+    $newlist .= "<li><a href=\"$db_url$myrow[1]\">$myrow[0]</a></li>\n";
 }
 $newlist .= "</ul>\n";
 


### PR DESCRIPTION
On this page: https://your_subjectplus_domain/subjects/index.php
The list of Newest Databases all have [0] added to the ends of their URLs, which is breaking the links.