### PR TITLE
Set the lang attribute on the HTML tag

### DIFF
--- a/templates/staff/base.html.twig
+++ b/templates/staff/base.html.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ app.request.locale }}">
     <head>
         <meta charset="UTF-8">
         <title>{% block title %}Welcome!{% endblock %}</title>


### PR DESCRIPTION
This allows screen readers to identify the language of the page's content.  See https://webaim.org/techniques/language/ for a more in-depth explanation.