### PR TITLE
fix: not showing credentials after installation

### DIFF
--- a/lib/SubjectsPlus/Control/Installer.php
+++ b/lib/SubjectsPlus/Control/Installer.php
@@ -622,14 +622,14 @@ class Installer
 
 		if( (file_exists($lstrRootPath . 'subjects' . DIRECTORY_SEPARATOR . '.htaccess-default')) &&  (!file_exists($lstrRootPath . 'subjects' . DIRECTORY_SEPARATOR . '.htaccess'))  ) {
 			$subjectsHtaccess = rename($lstrRootPath . 'subjects' . DIRECTORY_SEPARATOR . '.htaccess-default', $lstrRootPath . 'subjects' . DIRECTORY_SEPARATOR . '.htaccess');
-        } else {
+        
 			$subjectsHtaccess = $lstrRootPath . 'subjects' . DIRECTORY_SEPARATOR . '.htaccess';
 
         }
 
 		if( (file_exists($lstrRootPath . 'api' . DIRECTORY_SEPARATOR . '.htaccess-default')) &&  (!file_exists($lstrRootPath . 'api' . DIRECTORY_SEPARATOR . '.htaccess'))  ) {
-			$apiHtaccess = rename($lstrRootPath . 'subjects' . DIRECTORY_SEPARATOR . '.htaccess-default', $lstrRootPath . 'api' . DIRECTORY_SEPARATOR . '.htaccess');
-		} else {
+			$apiHtaccess = rename($lstrRootPath . 'api' . DIRECTORY_SEPARATOR . '.htaccess-default', $lstrRootPath . 'api' . DIRECTORY_SEPARATOR . '.htaccess');
+		
 			$apiHtaccess = $lstrRootPath . 'api' . DIRECTORY_SEPARATOR . '.htaccess';
 
 		}


### PR DESCRIPTION
Many users reported in the SubjectsPlus group an error in the installation, an error that did not allow to show the credentials of the admin user after the installation.

- https://groups.google.com/g/subjectsplus/c/RKzzPWR-BhQ
- https://groups.google.com/g/subjectsplus/c/EuMbiF8c0Ng
- https://groups.google.com/g/subjectsplus/c/Xac1i53tbYs

The error was because the rewriteHtaccessFileNames() function was not correctly renaming the .htaccess files correctly due to an error in the location of these files.

On the other hand, the same code did not return the correct path for the updateRewriteBases() function to rewrite the code correctly.